### PR TITLE
Replace legacy zgw client with zgw_consumers.NLXClient

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11']
-        django: ['3.2', '4.0', '4.2']
+        python: ['3.10', '3.11']
+        django: ['4.2']
     name: Run the test suite (Python ${{ matrix.python }}, Django ${{ matrix.django }})
 
     steps:

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -17,7 +17,10 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.admin",
+    "requests",
     "solo",
+    "simple_certmanager",
+    "zgw_consumers",
     "objectsapiclient",
     "testapp",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,310,311}-django{32,40,42}
+    py{310,311}-django{42}
     isort
     black
     flake8
@@ -9,8 +9,6 @@ skip_missing_interpreters = true
 
 [gh-actions:env]
 DJANGO =
-    3.2: django32
-    4.0: django40
     4.2: django42
 
 [testenv]
@@ -21,8 +19,6 @@ extras =
     tests
     coverage
 deps =
-  django32: Django~=3.2.0
-  django40: Django~=4.0.0
   django42: Django~=4.2.0
 commands =
   py.test tests \


### PR DESCRIPTION
The client for interfacing with the Objects API and Objecttypes API is using a deprecated zgw consumers client.