### PR TITLE
Fix error on client create when no service configured

### DIFF
--- a/objectsapiclient/client.py
+++ b/objectsapiclient/client.py
@@ -18,9 +18,6 @@ class Client:
             service=object_types_api_service
         )
 
-    def has_config(self) -> bool:
-        return self.objects_api_client and self.object_types_api_client
-
     def is_healthy(self) -> Tuple[bool, str]:
         """ """
         try:

--- a/objectsapiclient/models.py
+++ b/objectsapiclient/models.py
@@ -5,7 +5,6 @@ from django.db import models
 from django.db.models.fields import BLANK_CHOICE_DASH
 from django.forms.fields import TypedChoiceField
 from django.forms.widgets import Select
-from django.utils.functional import cached_property
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy as _
 
@@ -43,9 +42,12 @@ class Configuration(SingletonModel):
     def __str__(self):
         return "Objects API client configuration"
 
-    @cached_property
+    @property
     def client(self):
-        return Client(self.objects_api_service, self.object_type_api_service)
+        try:
+            return Client(self.objects_api_service, self.object_type_api_service)
+        except AttributeError:
+            return None
 
 
 class ObjectTypeField(models.SlugField):

--- a/objectsapiclient/utils.py
+++ b/objectsapiclient/utils.py
@@ -10,7 +10,7 @@ def get_object_type_choices(client=None, use_uuids=False):
         config = Configuration.get_solo()
         client = config.client
 
-    if not client.has_config():
+    if not client:
         return []
 
     objecttypes = client.get_object_types()


### PR DESCRIPTION
Accessing the client on the configuration results in `AttributeError` if the services are not configured (checking whether the services are configured (with `has_config`) comes too late). 

The PR changes this behavior as follows: we catch the error when creating the client, return `None` for this case, and then check if the client exists in functions/methods that make use of the client.