### PR TITLE
Refactor objects api client and configuration 

### DIFF
--- a/objectsapiclient/admin.py
+++ b/objectsapiclient/admin.py
@@ -3,8 +3,8 @@ from django.utils.html import format_html
 
 from solo.admin import SingletonModelAdmin
 
-from .models import ObjectsClientConfiguration
 from .client import Client
+from .models import ObjectsClientConfiguration
 
 
 @admin.register(ObjectsClientConfiguration)

--- a/objectsapiclient/admin.py
+++ b/objectsapiclient/admin.py
@@ -3,18 +3,19 @@ from django.utils.html import format_html
 
 from solo.admin import SingletonModelAdmin
 
-from .models import Configuration
+from .models import ObjectsClientConfiguration
+from .client import Client
 
 
-@admin.register(Configuration)
-class ConfigurationAdmin(SingletonModelAdmin):
+@admin.register(ObjectsClientConfiguration)
+class ObjectsServiceConfigurationAdmin(SingletonModelAdmin):
     fieldsets = (
         (
             None,
             {
                 "fields": (
-                    "objects_api_service",
-                    "object_type_api_service",
+                    "objects_api_service_config",
+                    "object_type_api_service_config",
                     "status",
                 )
             },
@@ -26,5 +27,7 @@ class ConfigurationAdmin(SingletonModelAdmin):
     def status(self, obj):
         from django.contrib.admin.templatetags.admin_list import _boolean_icon
 
-        healthy, message = obj.client.is_healthy()
+        client = Client()
+
+        healthy, message = client.is_healthy()
         return format_html("{} {}", _boolean_icon(healthy), message)

--- a/objectsapiclient/migrations/0002_auto_20230917_1644.py
+++ b/objectsapiclient/migrations/0002_auto_20230917_1644.py
@@ -34,4 +34,10 @@ class Migration(migrations.Migration):
                 to="zgw_consumers.service",
             ),
         ),
+        migrations.AlterModelOptions(
+            name="objectsapiserviceconfiguration",
+            options={
+                "verbose_name": "Objects API service configuration",
+            },
+        ),
     ]

--- a/objectsapiclient/migrations/0003_rename_config_model_fields.py
+++ b/objectsapiclient/migrations/0003_rename_config_model_fields.py
@@ -1,0 +1,28 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        (
+            "objectsapiclient",
+            "0002_auto_20230917_1644",
+        ),  # update with your last migration
+    ]
+
+    operations = [
+        migrations.RenameModel(
+            old_name="Configuration",
+            new_name="ObjectsClientConfiguration",
+        ),
+        migrations.RenameField(
+            model_name="objectsclientconfiguration",
+            old_name="objects_api_service",
+            new_name="objects_api_service_config",
+        ),
+        migrations.RenameField(
+            model_name="objectsclientconfiguration",
+            old_name="object_type_api_service",
+            new_name="object_type_api_service_config",
+        ),
+    ]

--- a/objectsapiclient/models.py
+++ b/objectsapiclient/models.py
@@ -10,30 +10,29 @@ from django.utils.translation import gettext_lazy as _
 
 from solo.models import SingletonModel
 
-from .client import Client
 from .utils import get_object_type_choices
 
 logger = logging.getLogger(__name__)
 
 
-class Configuration(SingletonModel):
+class ObjectsClientConfiguration(SingletonModel):
     """
-    The Objects API configuration to retrieve and render forms.
+    The Objects API client configuration to retrieve and render forms.
     """
 
-    objects_api_service = models.ForeignKey(
+    objects_api_service_config = models.ForeignKey(
         "zgw_consumers.Service",
         on_delete=models.CASCADE,
         null=True,
         blank=True,
-        related_name="objects_api_service",
+        related_name="objects_api_service_config",
     )
-    object_type_api_service = models.ForeignKey(
+    object_type_api_service_config = models.ForeignKey(
         "zgw_consumers.Service",
         on_delete=models.CASCADE,
         null=True,
         blank=True,
-        related_name="object_type_api_service",
+        related_name="object_type_api_service_config",
     )
 
     class Meta:
@@ -41,13 +40,6 @@ class Configuration(SingletonModel):
 
     def __str__(self):
         return "Objects API client configuration"
-
-    @property
-    def client(self):
-        try:
-            return Client(self.objects_api_service, self.object_type_api_service)
-        except AttributeError:
-            return None
 
 
 class ObjectTypeField(models.SlugField):

--- a/objectsapiclient/models.py
+++ b/objectsapiclient/models.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 
 from django.core.cache import cache
@@ -60,12 +61,10 @@ class ObjectTypeField(models.SlugField):
             "required": not self.blank,
             "label": capfirst(self.verbose_name),
             "help_text": self.help_text,
+            "choices": functools.partial(self.get_choices, include_blank=self.blank),
+            "coerce": self.to_python,
             "widget": Select,
         }
-
-        defaults["choices"] = self.get_choices(include_blank=self.blank)
-        defaults["coerce"] = self.to_python
-
         return TypedChoiceField(**defaults)
 
     def get_choices(

--- a/objectsapiclient/utils.py
+++ b/objectsapiclient/utils.py
@@ -3,13 +3,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def get_object_type_choices(client=None, use_uuids=False):
-    if client is None:
-        from .models import Configuration
+def get_object_type_choices(use_uuids=False):
+    from .client import Client
 
-        config = Configuration.get_solo()
-        client = config.client
-
+    client = Client()
     if not client:
         return []
 


### PR DESCRIPTION
- Invert dependency between the objects service and the configuration (previously the configuration had the client as a property, so the user would do `config.client.do_stuff()`. The dependency is reverted so that the client module imports and uses the configuration, not the other way around)
- Lazy-load choices for `ObjectTypeField`. The choices are currently loaded when the class is imported, leading to errors in case of missing configurations for the Objects API and ObjectTypes API)