### PR TITLE
Add/correct metadata

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 
 
 Objects API Client (for Django)
-==============================
+===============================
 
 :Version: 0.1.0
 :Source: https://github.com/maykinmedia/objects-api-client-django

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ name = objects-api-client-django
 version = 0.1.0
 description = Easily integrate Objects API in your Django application.
 long_description = file: README.rst
+long_description_content_type = text/x-rst
 url = https://github.com/maykinmedia/objects-api-client-django
 license = MIT
 author = Maykin Media


### PR DESCRIPTION
- `long_description_content_type` was missing from `setup.cfg`
- README had a syntax error